### PR TITLE
Add ability to manage ZED_USE_ENCLOSURE_LEDS setting in zed.rc template

### DIFF
--- a/manifests/zed.pp
+++ b/manifests/zed.pp
@@ -23,6 +23,7 @@
 # @param spare_on_io_errors
 # @param syslog_priority
 # @param syslog_tag
+# @param use_enclosure_leds
 # @param zedlet_dir Path to package-provided zedlets.
 # @param zedlets Hash of zedlet resources to create.
 #
@@ -49,6 +50,7 @@ class zfs::zed (
   Optional[Integer[1]]           $spare_on_io_errors       = undef,
   Optional[String]               $syslog_priority          = undef,
   Optional[String]               $syslog_tag               = undef,
+  Optional[Boolean]              $use_enclosure_leds       = undef,
   Stdlib::Absolutepath           $zedlet_dir               = $::zfs::params::zedlet_dir,
   Hash[String, Hash]             $zedlets                  = $::zfs::params::zedlets,
 ) inherits ::zfs::params {

--- a/manifests/zed/config.pp
+++ b/manifests/zed/config.pp
@@ -16,6 +16,7 @@ class zfs::zed::config {
   $spare_on_checksum_errors = $::zfs::zed::spare_on_checksum_errors
   $spare_on_io_errors       = $::zfs::zed::spare_on_io_errors
   $syslog_priority          = $::zfs::zed::syslog_priority
+  $use_enclosure_leds       = $::zfs::zed::use_enclosure_leds
   $syslog_tag               = $::zfs::zed::syslog_tag
   $zedlet_dir               = $::zfs::zed::zedlet_dir
 

--- a/templates/zed.rc.erb
+++ b/templates/zed.rc.erb
@@ -29,6 +29,9 @@ ZED_PUSHBULLET_CHANNEL_TAG="<%= @pushbullet_channel_tag %>"
 <% if @run_dir -%>
 ZED_RUNDIR="<%= @run_dir %>"
 <% end -%>
+<% if @use_enclosure_leds -%>
+ZED_USE_ENCLOSURE_LEDS="<%= @use_enclosure_leds ? 1 : 0 %>"
+<% end -%>
 <% if @spare_on_checksum_errors -%>
 ZED_SPARE_ON_CHECKSUM_ERRORS=<%= @spare_on_checksum_errors %>
 <% end -%>


### PR DESCRIPTION
While working with zfs 0.7.3 on CentOS 7.4, there was a parameter in the zed.rc file that was being removed from a default installation by the module. This adds the ability to manage  ZED_USE_ENCLOSURE_LEDS with a use_enclosure_leds parameter in the template. I based functionality on how ZED_NOTIFY_VERBOSE is managed with the notify_verbose parameter.