### PR TITLE
Install linux headers meta package on Debian

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -105,7 +105,7 @@ class zfs::install {
           # noop
         }
         default: {
-          ensure_packages(["linux-headers-${::kernelrelease}"], {
+          ensure_packages(["linux-headers-${::architecture}"], {
             before => Package[$::zfs::package_name],
           })
         }

--- a/spec/classes/zfs_spec.rb
+++ b/spec/classes/zfs_spec.rb
@@ -67,7 +67,7 @@ describe 'zfs' do
             it { is_expected.to contain_service('zfs-share') }
           end
         else
-          it { is_expected.to contain_package("linux-headers-#{facts[:kernelrelease]}") }
+          it { is_expected.to contain_package("linux-headers-#{facts[:architecture]}") }
           it { is_expected.to contain_package('zfs-dkms') }
           it { is_expected.to contain_package('zfsutils-linux') }
           it { is_expected.to contain_service('zfs-import-cache').with_ensure('stopped') }


### PR DESCRIPTION
During kernel updates we want zfs kernel modules to be
automatically rebuilt for new kernel. To get this working we need
linux headers to be updated together with kernel and meta package
will do this for us.