### PR TITLE
Drop librarian and install fixtures manually

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,19 @@
 fixtures:
   symlinks:
     zfs: "#{source_dir}"
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "4.13.0"
+    apt:
+      repo: "puppetlabs/apt"
+      ref: "2.2.0"
+    kmod:
+      repo: "camptocamp/kmod"
+      ref: "2.0.0"
+    augeas_core:
+      repo: "puppetlabs/augeas_core"
+      ref: "1.0.1"
+    cron_core:
+      repo: "puppetlabs/cron_core"
+      ref: "1.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development, :test do
   gem 'puppet-lint-fileserver-check',                     :require => false, :git => 'https://github.com/bodgit/puppet-lint-fileserver-check.git', :branch => 'puppet-lint-2.x'
   gem 'puppet-lint-file_source_rights-check',             :require => false
   gem 'puppet-lint-alias-check',                          :require => false
-  gem 'librarian-puppet',                                 :require => false
   gem 'beaker', '>= 3.0.0',                               :require => false
   gem 'beaker-rspec', '>= 6.0.0',                         :require => false
   gem 'rspec-puppet-facts', '>= 1.1.1',                   :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -7,17 +7,6 @@ require 'puppet-strings/tasks'
 CLEAN.include('spec/fixtures/manifests', 'spec/fixtures/modules')
 CLOBBER.include('.tmp', '.librarian', '.vagrant', 'Puppetfile.lock', 'log', 'junit', 'coverage', 'doc')
 
-task :spec => []; Rake::Task[:spec].clear
-task :spec do
-  Rake::Task[:spec_prep].invoke
-  Rake::Task[:spec_standalone].invoke
-end
-
-task :librarian_spec_prep do
-  sh 'librarian-puppet install --path=spec/fixtures/modules/'
-end
-task :spec_prep => :librarian_spec_prep
-
 task :test => [
   'metadata_lint',
   'syntax',


### PR DESCRIPTION
This should stop picking the latest versions of modules which seems to
explode with the apt module.