### PR TITLE
Preliminary Debian 10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The module has been tested on:
 
 * RedHat Enterprise Linux 6/7/8
 * Ubuntu 16.04, 18.04
-* Debian 8, 9
+* Debian 8/9/10
 
 It should also work on Ubuntu 12.04/14.04 however the quality of some aspects
 of the packages make it difficult for the module to work properly.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -138,7 +138,8 @@ class zfs::install {
 
       Exec['zfs systemctl daemon-reload'] -> Package[$::zfs::package_name]
 
-      ['zfs-import-cache', 'zfs-import-scan'].each |$service| {
+      # The last one is for Debian 10 only
+      ['zfs-import-cache', 'zfs-import-scan', 'zfs-mount'].each |$service| {
         file { "/etc/systemd/system/${service}.service.d":
           ensure => directory,
           owner  => 0,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,20 +103,39 @@ class zfs::params {
           $manage_repo      = true
           $zed_service_name = 'zfs-zed'
           $zedlet_dir       = '/usr/lib/x86_64-linux-gnu/zfs/zed.d'
-          $zedlets          = {
-            'all-syslog.sh'             => {},
-            'checksum-notify.sh'        => {},
-            'checksum-spare.sh'         => {},
-            'data-notify.sh'            => {},
-            'io-notify.sh'              => {},
-            'io-spare.sh'               => {},
-            'resilver.finish-notify.sh' => {},
-            'scrub.finish-notify.sh'    => {},
-          }
           $zfs_package_name = [
             'zfs-dkms',
             'zfsutils-linux',
           ]
+
+          case $::operatingsystemmajrelease {
+            '8', '9': {
+              $zedlets = {
+                'all-syslog.sh'             => {},
+                'checksum-notify.sh'        => {},
+                'checksum-spare.sh'         => {},
+                'data-notify.sh'            => {},
+                'io-notify.sh'              => {},
+                'io-spare.sh'               => {},
+                'resilver.finish-notify.sh' => {},
+                'scrub.finish-notify.sh'    => {},
+              }
+            }
+            default: {
+              $zedlets = {
+                'all-syslog.sh'                  => {},
+                'data-notify.sh'                 => {},
+                'pool_import-led.sh'             => {},
+                'resilver_finish-notify.sh'      => {},
+                'resilver_finish-start-scrub.sh' => {},
+                'scrub_finish-notify.sh'         => {},
+                'statechange-led.sh'             => {},
+                'statechange-notify.sh'          => {},
+                'vdev_attach-led.sh'             => {},
+                'vdev_clear-led.sh'              => {},
+              }
+            }
+          }
         }
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],

--- a/spec/acceptance/nodesets/debian-10-x64.yml
+++ b/spec/acceptance/nodesets/debian-10-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  debian-10-x64:
+    roles:
+      - master
+    platform: debian-10-amd64
+    box: debian/buster64
+    box_url: https://vagrantcloud.com/debian/boxes/buster64
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/spec/acceptance/zfs_spec.rb
+++ b/spec/acceptance/zfs_spec.rb
@@ -69,8 +69,9 @@ describe 'zfs' do
                 }
                 default: {
                   $snapshot = $::kernelrelease ? {
-                    /^4\.9\.0-9-/ => '20190601T035633Z',
-                    default       => undef,
+                    /^4\.9\.0-9-/  => '20190601T035633Z',
+                    /^4\.19\.0-5-/ => '20190701T031013Z',
+                    default        => undef,
                   }
 
                   if $snapshot {

--- a/spec/classes/zfs_spec.rb
+++ b/spec/classes/zfs_spec.rb
@@ -99,6 +99,8 @@ describe 'zfs' do
           it { is_expected.to contain_file('/etc/systemd/system/zfs-import-cache.service.d') }
           it { is_expected.to contain_file('/etc/systemd/system/zfs-import-scan.service.d/override.conf') }
           it { is_expected.to contain_file('/etc/systemd/system/zfs-import-scan.service.d') }
+          it { is_expected.to contain_file('/etc/systemd/system/zfs-mount.service.d/override.conf') }
+          it { is_expected.to contain_file('/etc/systemd/system/zfs-mount.service.d') }
           it { is_expected.to contain_service('zfs-import-cache').with_ensure('stopped') }
           it { is_expected.to contain_service('zfs-import-scan').with_ensure('running') }
         end

--- a/spec/classes/zfs_zed_spec.rb
+++ b/spec/classes/zfs_zed_spec.rb
@@ -98,18 +98,37 @@ describe 'zfs::zed' do
             it { is_expected.to contain_exec('systemctl daemon-reload') }
             it { is_expected.to contain_file('/etc/systemd/system/zfs-zed.service.d') }
             it { is_expected.to contain_file('/etc/systemd/system/zfs-zed.service.d/override.conf') }
-            [
-              'all-syslog.sh',
-              'checksum-notify.sh',
-              'checksum-spare.sh',
-              'data-notify.sh',
-              'io-notify.sh',
-              'io-spare.sh',
-              'resilver.finish-notify.sh',
-              'scrub.finish-notify.sh',
-            ].each do |x|
-              it { is_expected.to contain_file("/etc/zfs/zed.d/#{x}") }
-              it { is_expected.to contain_zfs__zed__zedlet(x) }
+            case facts[:operatingsystemmajrelease]
+            when '8', '9'
+              [
+                'all-syslog.sh',
+                'checksum-notify.sh',
+                'checksum-spare.sh',
+                'data-notify.sh',
+                'io-notify.sh',
+                'io-spare.sh',
+                'resilver.finish-notify.sh',
+                'scrub.finish-notify.sh',
+              ].each do |x|
+                it { is_expected.to contain_file("/etc/zfs/zed.d/#{x}") }
+                it { is_expected.to contain_zfs__zed__zedlet(x) }
+              end
+            else
+              [
+                'all-syslog.sh',
+                'data-notify.sh',
+                'pool_import-led.sh',
+                'resilver_finish-notify.sh',
+                'resilver_finish-start-scrub.sh',
+                'scrub_finish-notify.sh',
+                'statechange-led.sh',
+                'statechange-notify.sh',
+                'vdev_attach-led.sh',
+                'vdev_clear-led.sh',
+              ].each do |x|
+                it { is_expected.to contain_file("/etc/zfs/zed.d/#{x}") }
+                it { is_expected.to contain_zfs__zed__zedlet(x) }
+              end
             end
             it { is_expected.to contain_service('zfs-zed') }
           end


### PR DESCRIPTION
The Vagrant box breaks the tests, installing the zfs-dkms package results in the zfs kernel module erroring with "exec format error". Updating the kernel to a later version fixes this but is impractical as part of the beaker framework.

Fixes #21 