### PR TITLE
Fix broken references to "kabi" kmod type, should be "kmod"

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ and tune the ARC, you can do:
 
 ```puppet
 class { '::zfs':
-  kmod_type   => 'kabi',
+  kmod_type   => 'kmod',
   zfs_arc_max => to_bytes('256 M'),
   zfs_arc_min => to_bytes('128 M'),
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@
 # @see puppet_defined_types::zfs::scrub ::zfs::scrub
 class zfs (
   Stdlib::Absolutepath              $conf_dir            = $::zfs::params::conf_dir,
-  Enum['dkms', 'kabi']              $kmod_type           = $::zfs::params::kmod_type,
+  Enum['dkms', 'kmod']              $kmod_type           = $::zfs::params::kmod_type,
   Boolean                           $manage_repo         = $::zfs::params::manage_repo,
   Variant[String, Array[String, 1]] $package_name        = $::zfs::params::zfs_package_name,
   Boolean                           $service_manage      = $::zfs::params::service_manage,


### PR DESCRIPTION
kmod type `"kabi"` was used in two places, but everything else refers to `"kmod"` 